### PR TITLE
Calculate accurate betting statistics from $100

### DIFF
--- a/src/components/ROIAnalytics.module.css
+++ b/src/components/ROIAnalytics.module.css
@@ -185,6 +185,13 @@
   color: #DC2626;
 }
 
+.roiSubtext {
+  font-size: 0.75rem;
+  color: #64748B;
+  font-weight: 500;
+  margin-top: 0.5rem;
+}
+
 .roiNote {
   margin-top: 0.75rem;
   padding: 0.75rem;

--- a/src/components/ROIAnalytics.module.css
+++ b/src/components/ROIAnalytics.module.css
@@ -457,6 +457,212 @@
   }
 }
 
+/* Goal Tracking Styles */
+.goalProgress {
+  margin-bottom: 1.5rem;
+}
+
+.progressBar {
+  width: 100%;
+  height: 12px;
+  background: #E5E7EB;
+  border-radius: 6px;
+  overflow: hidden;
+  margin-bottom: 0.5rem;
+}
+
+.progressFill {
+  height: 100%;
+  background: linear-gradient(90deg, #059669, #10B981);
+  border-radius: 6px;
+  transition: width 0.3s ease;
+}
+
+.progressText {
+  text-align: center;
+  font-size: 1rem;
+  font-weight: 700;
+  color: #1F2937;
+}
+
+.goalMetrics {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 1rem;
+  margin-bottom: 1.5rem;
+}
+
+.goalCard {
+  background: #ffffff;
+  border-radius: 10px;
+  padding: 1rem;
+  text-align: center;
+  border: 2px solid #E5E7EB;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.05);
+}
+
+.goalLabel {
+  font-size: 0.8rem;
+  color: #64748B;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.025em;
+  margin-bottom: 0.5rem;
+}
+
+.goalValue {
+  font-size: 1.1rem;
+  font-weight: 800;
+  color: #1F2937;
+  margin-bottom: 0.25rem;
+}
+
+.goalSubtext {
+  font-size: 0.7rem;
+  color: #9CA3AF;
+  font-weight: 500;
+}
+
+.goalProjection {
+  margin-top: 1.5rem;
+}
+
+.goalAchieved {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  padding: 1.5rem;
+  background: linear-gradient(135deg, #D1FAE5, #A7F3D0);
+  border-radius: 12px;
+  border: 2px solid #059669;
+}
+
+.goalAchievedIcon {
+  font-size: 2rem;
+}
+
+.goalAchievedText h3 {
+  margin: 0 0 0.5rem 0;
+  color: #059669;
+  font-size: 1.25rem;
+  font-weight: 800;
+}
+
+.goalAchievedText p {
+  margin: 0;
+  color: #065F46;
+  font-weight: 600;
+}
+
+.goalEstimate {
+  background: #ffffff;
+  border-radius: 12px;
+  border: 2px solid #E5E7EB;
+  overflow: hidden;
+}
+
+.goalEstimateHeader {
+  background: #F8FAFC;
+  padding: 1rem;
+  border-bottom: 1px solid #E5E7EB;
+}
+
+.goalEstimateHeader h3 {
+  margin: 0;
+  color: #1F2937;
+  font-size: 1rem;
+  font-weight: 800;
+}
+
+.goalEstimateGrid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 0;
+}
+
+.goalEstimateItem {
+  padding: 1rem;
+  border-right: 1px solid #E5E7EB;
+  border-bottom: 1px solid #E5E7EB;
+}
+
+.goalEstimateItem:nth-child(2n) {
+  border-right: none;
+}
+
+.goalEstimateItem:nth-last-child(-n+2) {
+  border-bottom: none;
+}
+
+.goalEstimateLabel {
+  font-size: 0.8rem;
+  color: #64748B;
+  font-weight: 700;
+  margin-bottom: 0.5rem;
+}
+
+.goalEstimateValue {
+  font-size: 1rem;
+  font-weight: 800;
+  color: #1F2937;
+}
+
+.goalNote {
+  padding: 1rem;
+  background: #F0F9FF;
+  border-top: 1px solid #E5E7EB;
+}
+
+.goalNote p {
+  margin: 0 0 0.5rem 0;
+  font-size: 0.8rem;
+  color: #0369A1;
+  font-weight: 500;
+}
+
+.goalNote p:last-child {
+  margin-bottom: 0;
+}
+
+.goalWarning {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  padding: 1.5rem;
+  background: linear-gradient(135deg, #FEF3C7, #FDE68A);
+  border-radius: 12px;
+  border: 2px solid #F59E0B;
+}
+
+.goalWarningIcon {
+  font-size: 2rem;
+}
+
+.goalWarningText h3 {
+  margin: 0 0 0.5rem 0;
+  color: #92400E;
+  font-size: 1.1rem;
+  font-weight: 800;
+}
+
+.goalWarningText p {
+  margin: 0 0 0.5rem 0;
+  color: #78350F;
+  font-weight: 600;
+  font-size: 0.9rem;
+}
+
+.goalWarningText p:last-child {
+  margin-bottom: 0;
+}
+
+.goalNoData {
+  text-align: center;
+  padding: 2rem;
+  color: #64748B;
+  font-weight: 600;
+}
+
 /* Landscape Mobile */
 @media (max-width: 896px) and (orientation: landscape) {
   .roiGraph {
@@ -473,5 +679,26 @@
   
   .roiComparison {
     flex-direction: row;
+  }
+}
+
+/* Mobile Responsive for Goal Tracking */
+@media (max-width: 640px) {
+  .goalMetrics {
+    grid-template-columns: 1fr;
+  }
+  
+  .goalEstimateGrid {
+    grid-template-columns: 1fr;
+  }
+  
+  .goalEstimateItem {
+    border-right: none;
+  }
+  
+  .goalAchieved, .goalWarning {
+    flex-direction: column;
+    text-align: center;
+    gap: 0.75rem;
   }
 }

--- a/src/components/ROIAnalytics.tsx
+++ b/src/components/ROIAnalytics.tsx
@@ -108,11 +108,16 @@ export default function ROIAnalytics() {
       const today = new Date()
       timeInMarketDays = Math.max(1, Math.floor((today.getTime() - firstBetDate.getTime()) / (1000 * 60 * 60 * 24)))
       
-      // Calculate annualized return
+      // Calculate annualized return - only if we have enough data (at least 7 days)
       const yearsInMarket = timeInMarketDays / 365.25
-      if (yearsInMarket > 0 && currentBankroll > 0) {
+      if (timeInMarketDays >= 7 && yearsInMarket > 0 && currentBankroll > 0) {
         // Compound annual growth rate (CAGR) formula: (Ending Value / Beginning Value)^(1/years) - 1
-        averageYearlyReturn = (Math.pow(currentBankroll / STARTING_BANKROLL, 1 / yearsInMarket) - 1) * 100
+        const cagr = (Math.pow(currentBankroll / STARTING_BANKROLL, 1 / yearsInMarket) - 1) * 100
+        // Cap at reasonable limits (-99% to +10000%)
+        averageYearlyReturn = Math.max(-99, Math.min(10000, cagr))
+      } else {
+        // For periods less than 7 days, don't calculate annualized return
+        averageYearlyReturn = 0
       }
     }
 
@@ -372,7 +377,10 @@ export default function ROIAnalytics() {
           <div className={styles.metricCard}>
             <div className={styles.metricLabel}>Annualized Return</div>
             <div className={`${styles.metricValue} ${roiData.averageYearlyReturn >= 0 ? styles.positive : styles.negative}`}>
-              {roiData.averageYearlyReturn >= 0 ? '+' : ''}{roiData.averageYearlyReturn.toFixed(2)}%
+              {roiData.timeInMarketDays < 7 
+                ? 'N/A (< 7 days)'
+                : `${roiData.averageYearlyReturn >= 0 ? '+' : ''}${roiData.averageYearlyReturn.toFixed(2)}%`
+              }
             </div>
           </div>
           <div className={styles.metricCard}>
@@ -434,10 +442,16 @@ export default function ROIAnalytics() {
           <div className={styles.roiCard}>
             <div className={styles.roiLabel}>Annualized Return</div>
             <div className={`${styles.roiValue} ${roiData.averageYearlyReturn >= 0 ? styles.positive : styles.negative}`}>
-              {roiData.averageYearlyReturn >= 0 ? '+' : ''}{roiData.averageYearlyReturn.toFixed(2)}%
+              {roiData.timeInMarketDays < 7 
+                ? 'N/A'
+                : `${roiData.averageYearlyReturn >= 0 ? '+' : ''}${roiData.averageYearlyReturn.toFixed(2)}%`
+              }
             </div>
             <div className={styles.roiSubtext}>
-              Based on {roiData.timeInMarketDays} days
+              {roiData.timeInMarketDays < 7 
+                ? `Need 7+ days (currently ${roiData.timeInMarketDays})`
+                : `Based on ${roiData.timeInMarketDays} days`
+              }
             </div>
           </div>
           <div className={styles.roiCard}>

--- a/src/components/ROIAnalytics.tsx
+++ b/src/components/ROIAnalytics.tsx
@@ -29,6 +29,14 @@ interface ROIData {
   cumulativeROI: number[]
   targetGrowth: number[]
   completedBetsCount: number
+  // New fields for accurate bankroll tracking
+  startingBankroll: number
+  currentBankroll: number
+  totalProfitLoss: number
+  bankrollGrowthPercentage: number
+  averageYearlyReturn: number
+  timeInMarketDays: number
+  winRate: number
 }
 
 export default function ROIAnalytics() {
@@ -36,11 +44,7 @@ export default function ROIAnalytics() {
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState('')
 
-  useEffect(() => {
-    fetchROIData()
-  }, [])
-
-  const fetchROIData = async () => {
+  const fetchROIData = useCallback(async () => {
     try {
       setLoading(true)
       setError('')
@@ -61,7 +65,11 @@ export default function ROIAnalytics() {
     } finally {
       setLoading(false)
     }
-  }
+  }, [])
+
+  useEffect(() => {
+    fetchROIData()
+  }, [fetchROIData])
 
   const calculateROI = (bets: BetData[]) => {
     const completedBets = bets.filter(bet => bet.result !== 'pending')
@@ -69,6 +77,9 @@ export default function ROIAnalytics() {
 
     const totalBets = bets.length
     const completedBetsCount = completedBets.length
+    
+    // Bankroll constants
+    const STARTING_BANKROLL = 100.00
     
     // Only calculate ROI based on completed bets
     const totalStakedCompleted = completedBets.reduce((sum, bet) => sum + bet.stake, 0)
@@ -83,31 +94,53 @@ export default function ROIAnalytics() {
     const pendingStake = pendingBets.reduce((sum, bet) => sum + bet.stake, 0)
     const maxPendingPayout = pendingBets.reduce((sum, bet) => sum + bet.potential_payout, 0)
 
-    // Current ROI calculation - ONLY based on completed bets
-    const netProfit = totalWon - totalLost
-    const currentROI = totalStakedCompleted > 0 ? (netProfit / totalStakedCompleted) * 100 : 0
+    // NEW BANKROLL-BASED CALCULATIONS
+    const totalProfitLoss = totalWon - totalLost // Net profit/loss from completed bets
+    const currentBankroll = STARTING_BANKROLL + totalProfitLoss
+    const bankrollGrowthPercentage = (totalProfitLoss / STARTING_BANKROLL) * 100
 
-    // Calculate cumulative ROI over time - ONLY for completed bets in chronological order
-    let cumulativeStaked = 0
+    // Calculate time in market for annualized return
+    let timeInMarketDays = 0
+    let averageYearlyReturn = 0
+    
+    if (bets.length > 0) {
+      const firstBetDate = new Date(bets[0].created_at)
+      const today = new Date()
+      timeInMarketDays = Math.max(1, Math.floor((today.getTime() - firstBetDate.getTime()) / (1000 * 60 * 60 * 24)))
+      
+      // Calculate annualized return
+      const yearsInMarket = timeInMarketDays / 365.25
+      if (yearsInMarket > 0 && currentBankroll > 0) {
+        // Compound annual growth rate (CAGR) formula: (Ending Value / Beginning Value)^(1/years) - 1
+        averageYearlyReturn = (Math.pow(currentBankroll / STARTING_BANKROLL, 1 / yearsInMarket) - 1) * 100
+      }
+    }
+
+    // Calculate win rate
+    const wonBets = completedBets.filter(bet => bet.result === 'won').length
+    const winRate = completedBetsCount > 0 ? (wonBets / completedBetsCount) * 100 : 0
+
+    // OLD ROI calculation for comparison (based on staked amount)
+    const traditionalROI = totalStakedCompleted > 0 ? (totalProfitLoss / totalStakedCompleted) * 100 : 0
+
+    // Calculate cumulative bankroll growth over time - ONLY for completed bets in chronological order
     let cumulativeProfit = 0
     const cumulativeROI: number[] = []
     const targetGrowth: number[] = []
 
     // Process only completed bets in chronological order for the graph
-    completedBets.forEach(bet => {
-      cumulativeStaked += bet.stake
-      
+    completedBets.forEach((bet, index) => {
       if (bet.result === 'won') {
         cumulativeProfit += bet.potential_payout - bet.stake // Net profit from this bet
       } else if (bet.result === 'lost') {
         cumulativeProfit -= bet.stake // Loss from this bet
       }
       
-      // Calculate cumulative ROI up to this point
-      const currentCumulativeROI = cumulativeStaked > 0 ? (cumulativeProfit / cumulativeStaked) * 100 : 0
-      cumulativeROI.push(currentCumulativeROI)
+      // Calculate cumulative bankroll growth percentage up to this point
+      const currentBankrollGrowth = (cumulativeProfit / STARTING_BANKROLL) * 100
+      cumulativeROI.push(currentBankrollGrowth)
       
-      // Target is always 5%
+      // Target is always 5% growth from starting bankroll
       targetGrowth.push(5.0)
     })
 
@@ -119,11 +152,19 @@ export default function ROIAnalytics() {
       pendingBets: pendingBets.length,
       pendingStake,
       maxPendingPayout,
-      currentROI,
+      currentROI: bankrollGrowthPercentage, // NOW BASED ON BANKROLL GROWTH
       projectedROI: 5.0,
       cumulativeROI,
       targetGrowth,
-      completedBetsCount
+      completedBetsCount,
+      // New bankroll tracking fields
+      startingBankroll: STARTING_BANKROLL,
+      currentBankroll,
+      totalProfitLoss,
+      bankrollGrowthPercentage,
+      averageYearlyReturn,
+      timeInMarketDays,
+      winRate
     })
   }
 
@@ -302,9 +343,48 @@ export default function ROIAnalytics() {
         {renderROIGraph()}
       </div>
 
-      {/* Current Performance */}
+      {/* Bankroll Performance */}
       <div className={styles.section}>
-        <h4 className={styles.sectionTitle}>Current Performance</h4>
+        <h4 className={styles.sectionTitle}>Bankroll Performance</h4>
+        <div className={styles.metricGrid}>
+          <div className={styles.metricCard}>
+            <div className={styles.metricLabel}>Starting Bankroll</div>
+            <div className={styles.metricValue}>${roiData.startingBankroll.toFixed(2)}</div>
+          </div>
+          <div className={styles.metricCard}>
+            <div className={styles.metricLabel}>Current Bankroll</div>
+            <div className={`${styles.metricValue} ${roiData.totalProfitLoss >= 0 ? styles.positive : styles.negative}`}>
+              ${roiData.currentBankroll.toFixed(2)}
+            </div>
+          </div>
+          <div className={styles.metricCard}>
+            <div className={styles.metricLabel}>Total P&L</div>
+            <div className={`${styles.metricValue} ${roiData.totalProfitLoss >= 0 ? styles.positive : styles.negative}`}>
+              ${roiData.totalProfitLoss >= 0 ? '+' : ''}${roiData.totalProfitLoss.toFixed(2)}
+            </div>
+          </div>
+          <div className={styles.metricCard}>
+            <div className={styles.metricLabel}>Bankroll Growth</div>
+            <div className={`${styles.metricValue} ${roiData.bankrollGrowthPercentage >= 0 ? styles.positive : styles.negative}`}>
+              {roiData.bankrollGrowthPercentage >= 0 ? '+' : ''}{roiData.bankrollGrowthPercentage.toFixed(2)}%
+            </div>
+          </div>
+          <div className={styles.metricCard}>
+            <div className={styles.metricLabel}>Annualized Return</div>
+            <div className={`${styles.metricValue} ${roiData.averageYearlyReturn >= 0 ? styles.positive : styles.negative}`}>
+              {roiData.averageYearlyReturn >= 0 ? '+' : ''}{roiData.averageYearlyReturn.toFixed(2)}%
+            </div>
+          </div>
+          <div className={styles.metricCard}>
+            <div className={styles.metricLabel}>Days Trading</div>
+            <div className={styles.metricValue}>{roiData.timeInMarketDays}</div>
+          </div>
+        </div>
+      </div>
+
+      {/* Betting Statistics */}
+      <div className={styles.section}>
+        <h4 className={styles.sectionTitle}>Betting Statistics</h4>
         <div className={styles.metricGrid}>
           <div className={styles.metricCard}>
             <div className={styles.metricLabel}>Total Bets</div>
@@ -315,7 +395,7 @@ export default function ROIAnalytics() {
             <div className={styles.metricValue}>{roiData.completedBetsCount}</div>
           </div>
           <div className={styles.metricCard}>
-            <div className={styles.metricLabel}>Staked (Completed)</div>
+            <div className={styles.metricLabel}>Total Staked</div>
             <div className={styles.metricValue}>${roiData.totalStaked.toFixed(2)}</div>
           </div>
           <div className={styles.metricCard}>
@@ -326,28 +406,53 @@ export default function ROIAnalytics() {
             <div className={styles.metricLabel}>Total Lost</div>
             <div className={styles.metricValue}>${roiData.totalLost.toFixed(2)}</div>
           </div>
+          <div className={styles.metricCard}>
+            <div className={styles.metricLabel}>Win Rate</div>
+            <div className={styles.metricValue}>
+              {roiData.completedBetsCount > 0 
+                ? `${roiData.winRate.toFixed(1)}%`
+                : 'N/A (No completed bets)'
+              }
+            </div>
+          </div>
         </div>
       </div>
 
       {/* ROI Comparison */}
       <div className={styles.section}>
-        <h4 className={styles.sectionTitle}>ROI Analysis</h4>
+        <h4 className={styles.sectionTitle}>Bankroll Growth Analysis</h4>
         <div className={styles.roiComparison}>
           <div className={styles.roiCard}>
-            <div className={styles.roiLabel}>Your Current ROI</div>
+            <div className={styles.roiLabel}>Total Bankroll Growth</div>
             <div className={`${styles.roiValue} ${roiData.currentROI >= 0 ? styles.positive : styles.negative}`}>
-              {roiData.currentROI.toFixed(2)}%
+              {roiData.currentROI >= 0 ? '+' : ''}{roiData.currentROI.toFixed(2)}%
+            </div>
+            <div className={styles.roiSubtext}>
+              From $100 to ${roiData.currentBankroll.toFixed(2)}
+            </div>
+          </div>
+          <div className={styles.roiCard}>
+            <div className={styles.roiLabel}>Annualized Return</div>
+            <div className={`${styles.roiValue} ${roiData.averageYearlyReturn >= 0 ? styles.positive : styles.negative}`}>
+              {roiData.averageYearlyReturn >= 0 ? '+' : ''}{roiData.averageYearlyReturn.toFixed(2)}%
+            </div>
+            <div className={styles.roiSubtext}>
+              Based on {roiData.timeInMarketDays} days
             </div>
           </div>
           <div className={styles.roiCard}>
             <div className={styles.roiLabel}>5% Target Growth</div>
             <div className={styles.roiValue}>
-              {roiData.projectedROI.toFixed(2)}%
+              +{roiData.projectedROI.toFixed(2)}%
+            </div>
+            <div className={styles.roiSubtext}>
+              Target: $105.00
             </div>
           </div>
         </div>
         <div className={styles.roiNote}>
-          <p>ROI calculated only from completed bets (won/lost), excluding pending bets</p>
+          <p><strong>New Accurate Calculation:</strong> ROI now based on your $100 starting bankroll, not total staked amount</p>
+          <p>This gives you the true percentage growth of your initial investment</p>
         </div>
       </div>
 

--- a/src/components/ROIAnalytics.tsx
+++ b/src/components/ROIAnalytics.tsx
@@ -190,8 +190,8 @@ export default function ROIAnalytics() {
       }
     }
 
-    // OLD ROI calculation for comparison (based on staked amount)
-    const traditionalROI = totalStakedCompleted > 0 ? (totalProfitLoss / totalStakedCompleted) * 100 : 0
+    // OLD ROI calculation for comparison (based on staked amount) - keeping for future reference
+    // const traditionalROI = totalStakedCompleted > 0 ? (totalProfitLoss / totalStakedCompleted) * 100 : 0
 
     // Calculate cumulative bankroll growth over time - ONLY for completed bets in chronological order
     let cumulativeProfit = 0
@@ -199,7 +199,7 @@ export default function ROIAnalytics() {
     const targetGrowth: number[] = []
 
     // Process only completed bets in chronological order for the graph
-    completedBets.forEach((bet, index) => {
+    completedBets.forEach((bet) => {
       if (bet.result === 'won') {
         cumulativeProfit += bet.potential_payout - bet.stake // Net profit from this bet
       } else if (bet.result === 'lost') {
@@ -584,7 +584,7 @@ export default function ROIAnalytics() {
                   <div className={styles.goalAchievedIcon}>🎉</div>
                   <div className={styles.goalAchievedText}>
                     <h3>Goal Achieved!</h3>
-                    <p>Congratulations! You've reached your $1000 target!</p>
+                    <p>Congratulations! You&apos;ve reached your $1000 target!</p>
                   </div>
                 </div>
               ) : roiData.estimatedBetsToGoal > 0 ? (

--- a/src/components/bet-tracking/ROIAnalytics.module.css
+++ b/src/components/bet-tracking/ROIAnalytics.module.css
@@ -185,6 +185,13 @@
   color: #DC2626;
 }
 
+.roiSubtext {
+  font-size: 0.75rem;
+  color: #64748B;
+  font-weight: 500;
+  margin-top: 0.5rem;
+}
+
 .roiNote {
   margin-top: 0.75rem;
   padding: 0.75rem;

--- a/src/components/bet-tracking/ROIAnalytics.module.css
+++ b/src/components/bet-tracking/ROIAnalytics.module.css
@@ -457,6 +457,212 @@
   }
 }
 
+/* Goal Tracking Styles */
+.goalProgress {
+  margin-bottom: 1.5rem;
+}
+
+.progressBar {
+  width: 100%;
+  height: 12px;
+  background: #E5E7EB;
+  border-radius: 6px;
+  overflow: hidden;
+  margin-bottom: 0.5rem;
+}
+
+.progressFill {
+  height: 100%;
+  background: linear-gradient(90deg, #059669, #10B981);
+  border-radius: 6px;
+  transition: width 0.3s ease;
+}
+
+.progressText {
+  text-align: center;
+  font-size: 1rem;
+  font-weight: 700;
+  color: #1F2937;
+}
+
+.goalMetrics {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 1rem;
+  margin-bottom: 1.5rem;
+}
+
+.goalCard {
+  background: #ffffff;
+  border-radius: 10px;
+  padding: 1rem;
+  text-align: center;
+  border: 2px solid #E5E7EB;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.05);
+}
+
+.goalLabel {
+  font-size: 0.8rem;
+  color: #64748B;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.025em;
+  margin-bottom: 0.5rem;
+}
+
+.goalValue {
+  font-size: 1.1rem;
+  font-weight: 800;
+  color: #1F2937;
+  margin-bottom: 0.25rem;
+}
+
+.goalSubtext {
+  font-size: 0.7rem;
+  color: #9CA3AF;
+  font-weight: 500;
+}
+
+.goalProjection {
+  margin-top: 1.5rem;
+}
+
+.goalAchieved {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  padding: 1.5rem;
+  background: linear-gradient(135deg, #D1FAE5, #A7F3D0);
+  border-radius: 12px;
+  border: 2px solid #059669;
+}
+
+.goalAchievedIcon {
+  font-size: 2rem;
+}
+
+.goalAchievedText h3 {
+  margin: 0 0 0.5rem 0;
+  color: #059669;
+  font-size: 1.25rem;
+  font-weight: 800;
+}
+
+.goalAchievedText p {
+  margin: 0;
+  color: #065F46;
+  font-weight: 600;
+}
+
+.goalEstimate {
+  background: #ffffff;
+  border-radius: 12px;
+  border: 2px solid #E5E7EB;
+  overflow: hidden;
+}
+
+.goalEstimateHeader {
+  background: #F8FAFC;
+  padding: 1rem;
+  border-bottom: 1px solid #E5E7EB;
+}
+
+.goalEstimateHeader h3 {
+  margin: 0;
+  color: #1F2937;
+  font-size: 1rem;
+  font-weight: 800;
+}
+
+.goalEstimateGrid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 0;
+}
+
+.goalEstimateItem {
+  padding: 1rem;
+  border-right: 1px solid #E5E7EB;
+  border-bottom: 1px solid #E5E7EB;
+}
+
+.goalEstimateItem:nth-child(2n) {
+  border-right: none;
+}
+
+.goalEstimateItem:nth-last-child(-n+2) {
+  border-bottom: none;
+}
+
+.goalEstimateLabel {
+  font-size: 0.8rem;
+  color: #64748B;
+  font-weight: 700;
+  margin-bottom: 0.5rem;
+}
+
+.goalEstimateValue {
+  font-size: 1rem;
+  font-weight: 800;
+  color: #1F2937;
+}
+
+.goalNote {
+  padding: 1rem;
+  background: #F0F9FF;
+  border-top: 1px solid #E5E7EB;
+}
+
+.goalNote p {
+  margin: 0 0 0.5rem 0;
+  font-size: 0.8rem;
+  color: #0369A1;
+  font-weight: 500;
+}
+
+.goalNote p:last-child {
+  margin-bottom: 0;
+}
+
+.goalWarning {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  padding: 1.5rem;
+  background: linear-gradient(135deg, #FEF3C7, #FDE68A);
+  border-radius: 12px;
+  border: 2px solid #F59E0B;
+}
+
+.goalWarningIcon {
+  font-size: 2rem;
+}
+
+.goalWarningText h3 {
+  margin: 0 0 0.5rem 0;
+  color: #92400E;
+  font-size: 1.1rem;
+  font-weight: 800;
+}
+
+.goalWarningText p {
+  margin: 0 0 0.5rem 0;
+  color: #78350F;
+  font-weight: 600;
+  font-size: 0.9rem;
+}
+
+.goalWarningText p:last-child {
+  margin-bottom: 0;
+}
+
+.goalNoData {
+  text-align: center;
+  padding: 2rem;
+  color: #64748B;
+  font-weight: 600;
+}
+
 /* Landscape Mobile */
 @media (max-width: 896px) and (orientation: landscape) {
   .roiGraph {
@@ -473,5 +679,26 @@
   
   .roiComparison {
     flex-direction: row;
+  }
+}
+
+/* Mobile Responsive for Goal Tracking */
+@media (max-width: 640px) {
+  .goalMetrics {
+    grid-template-columns: 1fr;
+  }
+  
+  .goalEstimateGrid {
+    grid-template-columns: 1fr;
+  }
+  
+  .goalEstimateItem {
+    border-right: none;
+  }
+  
+  .goalAchieved, .goalWarning {
+    flex-direction: column;
+    text-align: center;
+    gap: 0.75rem;
   }
 }

--- a/src/components/bet-tracking/ROIAnalytics.tsx
+++ b/src/components/bet-tracking/ROIAnalytics.tsx
@@ -108,11 +108,16 @@ export default function ROIAnalytics() {
       const today = new Date()
       timeInMarketDays = Math.max(1, Math.floor((today.getTime() - firstBetDate.getTime()) / (1000 * 60 * 60 * 24)))
       
-      // Calculate annualized return
+      // Calculate annualized return - only if we have enough data (at least 7 days)
       const yearsInMarket = timeInMarketDays / 365.25
-      if (yearsInMarket > 0 && currentBankroll > 0) {
+      if (timeInMarketDays >= 7 && yearsInMarket > 0 && currentBankroll > 0) {
         // Compound annual growth rate (CAGR) formula: (Ending Value / Beginning Value)^(1/years) - 1
-        averageYearlyReturn = (Math.pow(currentBankroll / STARTING_BANKROLL, 1 / yearsInMarket) - 1) * 100
+        const cagr = (Math.pow(currentBankroll / STARTING_BANKROLL, 1 / yearsInMarket) - 1) * 100
+        // Cap at reasonable limits (-99% to +10000%)
+        averageYearlyReturn = Math.max(-99, Math.min(10000, cagr))
+      } else {
+        // For periods less than 7 days, don't calculate annualized return
+        averageYearlyReturn = 0
       }
     }
 
@@ -372,7 +377,10 @@ export default function ROIAnalytics() {
           <div className={styles.metricCard}>
             <div className={styles.metricLabel}>Annualized Return</div>
             <div className={`${styles.metricValue} ${roiData.averageYearlyReturn >= 0 ? styles.positive : styles.negative}`}>
-              {roiData.averageYearlyReturn >= 0 ? '+' : ''}{roiData.averageYearlyReturn.toFixed(2)}%
+              {roiData.timeInMarketDays < 7 
+                ? 'N/A (< 7 days)'
+                : `${roiData.averageYearlyReturn >= 0 ? '+' : ''}${roiData.averageYearlyReturn.toFixed(2)}%`
+              }
             </div>
           </div>
           <div className={styles.metricCard}>
@@ -434,10 +442,16 @@ export default function ROIAnalytics() {
           <div className={styles.roiCard}>
             <div className={styles.roiLabel}>Annualized Return</div>
             <div className={`${styles.roiValue} ${roiData.averageYearlyReturn >= 0 ? styles.positive : styles.negative}`}>
-              {roiData.averageYearlyReturn >= 0 ? '+' : ''}{roiData.averageYearlyReturn.toFixed(2)}%
+              {roiData.timeInMarketDays < 7 
+                ? 'N/A'
+                : `${roiData.averageYearlyReturn >= 0 ? '+' : ''}${roiData.averageYearlyReturn.toFixed(2)}%`
+              }
             </div>
             <div className={styles.roiSubtext}>
-              Based on {roiData.timeInMarketDays} days
+              {roiData.timeInMarketDays < 7 
+                ? `Need 7+ days (currently ${roiData.timeInMarketDays})`
+                : `Based on ${roiData.timeInMarketDays} days`
+              }
             </div>
           </div>
           <div className={styles.roiCard}>

--- a/src/components/bet-tracking/ROIAnalytics.tsx
+++ b/src/components/bet-tracking/ROIAnalytics.tsx
@@ -190,8 +190,8 @@ export default function ROIAnalytics() {
       }
     }
 
-    // OLD ROI calculation for comparison (based on staked amount)
-    const traditionalROI = totalStakedCompleted > 0 ? (totalProfitLoss / totalStakedCompleted) * 100 : 0
+    // OLD ROI calculation for comparison (based on staked amount) - keeping for future reference
+    // const traditionalROI = totalStakedCompleted > 0 ? (totalProfitLoss / totalStakedCompleted) * 100 : 0
 
     // Calculate cumulative bankroll growth over time - ONLY for completed bets in chronological order
     let cumulativeProfit = 0
@@ -199,7 +199,7 @@ export default function ROIAnalytics() {
     const targetGrowth: number[] = []
 
     // Process only completed bets in chronological order for the graph
-    completedBets.forEach((bet, index) => {
+    completedBets.forEach((bet) => {
       if (bet.result === 'won') {
         cumulativeProfit += bet.potential_payout - bet.stake // Net profit from this bet
       } else if (bet.result === 'lost') {
@@ -584,7 +584,7 @@ export default function ROIAnalytics() {
                   <div className={styles.goalAchievedIcon}>🎉</div>
                   <div className={styles.goalAchievedText}>
                     <h3>Goal Achieved!</h3>
-                    <p>Congratulations! You've reached your $1000 target!</p>
+                    <p>Congratulations! You&apos;ve reached your $1000 target!</p>
                   </div>
                 </div>
               ) : roiData.estimatedBetsToGoal > 0 ? (


### PR DESCRIPTION
Recalculate bet tracker ROI and performance metrics based on a $100 starting bankroll to provide accurate growth and profitability insights.

The previous ROI calculation was based on the total amount staked, which did not accurately reflect the user's overall bankroll growth from their initial investment. This PR updates the logic to track the bankroll from a fixed starting point ($100), calculates true percentage growth, total profit/loss, and annualized returns, offering a much clearer picture of performance.

---
[Slack Thread](https://aidev-gz64679.slack.com/archives/C093Y7BMAUS/p1758494685697939?thread_ts=1758494685.697939&cid=C093Y7BMAUS)

<a href="https://cursor.com/background-agent?bcId=bc-e3629f9d-cedd-4bcc-bdc9-477c418c2e22"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-e3629f9d-cedd-4bcc-bdc9-477c418c2e22"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

